### PR TITLE
ユーザー登録処理とバリデーションの追加

### DIFF
--- a/app/controllers/admin/employees_controller.rb
+++ b/app/controllers/admin/employees_controller.rb
@@ -6,6 +6,20 @@ class Admin::EmployeesController < ApplicationController
 
   def create
     @employee = Employee.new(employee_params)
+    @employee.birth_date = @employee.concat_date(
+                                    "birth_date",
+                                    @employee.birth_date_year,
+                                    @employee.birth_date_month,
+                                    @employee.birth_date_day
+                                  )
+
+    @employee.join_date = @employee.concat_date(
+                                    "join_date",
+                                    @employee.join_date_year,
+                                    @employee.join_date_month,
+                                    @employee.join_date_day
+                                  )
+
     if @employee.valid?
       @employee.save
       flash[:success] = "社員情報の登録が完了しました"

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,11 +8,31 @@ class Employee < ApplicationRecord
                 :join_date_month,
                 :join_date_day
 
-  before_validation :join_birth_date, :join_assign_date
   before_save :create_employee_no, if: :new_record?
 
-  PREFIX_EMPLOYEE_NO = "ST"
-  SET_EMPLOYEE_NO_SQL = "select nextval('employees_id_seq')"
+  PREFIX_EMPLOYEE_NO = "ST".freeze
+  SET_EMPLOYEE_NO_SQL = "select nextval('employees_id_seq')".freeze
+  NAME_KANA_FORMAT = /\A[\p{katakana}]+\z/.freeze
+  EMAIL_FORAT = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :name_kana, presence: true, length: { maximum: 100 }, format: {with: NAME_KANA_FORMAT}
+  
+  validates :gender, presence: true
+  validates :employment_type, presence: true
+
+  validates :birth_date, presence: true
+  validates :join_date, presence: true
+  validates :email, presence: true, if: [:birth_date_year, :birth_date_month, :birth_date_day]
+
+  validates :email, presence: true, uniqueness: true, format: {with: EMAIL_FORAT}, length: {maximum: 256}
+
+  # 確認用のフィールドが必要
+  validates :password_digest, presence: true
+
+  # 未来日チェック
+  validate :exists_birth_date?
+  validate :exists_join_date?
 
   # 性別
   enum gender: {
@@ -30,20 +50,41 @@ class Employee < ApplicationRecord
   }
 
   def create_employee_no
-    self.employee_no = PREFIX_EMPLOYEE_NO.concat(
+    self.employee_no = PREFIX_EMPLOYEE_NO +
       (ActiveRecord::Base.connection.execute(SET_EMPLOYEE_NO_SQL)[0]["nextval"]
-      .to_s.rjust(4,"0")))
+      .to_s.rjust(4,"0"))
   end
 
-  # 生年月日を結合してフォーマットを整える
-  def join_birth_date
-    str_birth_date = birth_date_year.concat(birth_date_month.rjust(2, "0"), birth_date_day.rjust(2, "0"))
-    self.birth_date = self.create_date(str_birth_date)
+  # 日付の各パラメータを連結する
+  def concat_date(param_name, year, month, day)
+    if date_blank?(param_name)
+      year.concat(month.rjust(2, "0"), day.rjust(2, "0"))
+    else
+      nil
+    end
   end
 
-  # 入社年月日を結合してフォーマットを整える
-  def join_assign_date
-    str_join_date = join_date_year.concat(join_date_month.rjust(2, "0"), join_date_day.rjust(2, "0"))
-    self.join_date = self.create_date(str_join_date)
+  # 空チェックを行う
+  def date_blank?(param_name)
+    ![self.send("#{param_name}_year"), self.send("#{param_name}_month"), self.send("#{param_name}_day")].include?(nil)
+  end
+
+  def exists_birth_date?
+    if birth_date.present?
+      binding.pry
+      tmp_date_attributes = [birth_date_year, birth_date_month, birth_date_day].map(&:to_i)
+      unless Date.valid_date?(tmp_date_attributes[0], tmp_date_attributes[1], tmp_date_attributes[2])
+        errors.add(:birth_date, "存在しない日付です")
+      end
+    end
+  end
+
+  def exists_join_date?
+    if join_date.present?
+      tmp_date_attributes = [join_date_year, join_date_month, join_date_day].map(&:to_i)
+      unless Date.valid_date?(tmp_date_attributes[0], tmp_date_attributes[1], tmp_date_attributes[2])
+        errors.add(:join_date, "存在しない日付です")
+      end
+    end
   end
 end

--- a/app/validators/exists_date_validator.rb
+++ b/app/validators/exists_date_validator.rb
@@ -1,0 +1,9 @@
+class ExistsDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    begin
+      Date.parse(record)
+    rescue ArgumentError
+      record.errors[:attribute] << (options[:message] || "入力された日付は存在しません")
+    end
+  end
+end

--- a/app/validators/feature_time_validator.rb
+++ b/app/validators/feature_time_validator.rb
@@ -1,0 +1,7 @@
+class FeatureTimeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value > Date.today
+      record.errors[:attribute] << (options[:message] || "未来の日付は登録出来ません")
+    end
+  end
+end


### PR DESCRIPTION
Closes #15 

## 目的
- ユーザー登録時のバリデーションを追加する

### 実装内容
- 日付に関するカスタムバリデーションを切り出し
- model
  - バリデーションの追加
- コントローラ
  - 時刻のフォーマット編集処理の追加


### チェックリスト

- [x] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

### 参考資料

### 備考（実装していないこと）

### スクリーンショット（変更前・変更後）
